### PR TITLE
Fixed instructions and script for importing dataset

### DIFF
--- a/bin/import-dataset.sh
+++ b/bin/import-dataset.sh
@@ -5,7 +5,7 @@
 #######################################################################
 
 NUMBER_REGEX='^[0-9]+$'
-DEFAULT_DATASET_ARCHIVE_NAME='dataset-full-ratings.tar.gz'
+DEFAULT_DATASET_ARCHIVE_NAME='dataset.tar.gz'
 DEFAULT_BATCH_SIZE=20000
 DEFAULT_TEMP_DIR_NAME='tmp'
 
@@ -13,8 +13,8 @@ DEFAULT_TEMP_DIR_NAME='tmp'
 ALBUMS_DIRECTORY='albums'
 ARTISTS_DIRECTORY='artists'
 LANGUAGES_DIRECTORY='languages'
-RATINGS_ALBUMS_DIRECTORY='ratings-albums'
-RATINGS_ARTISTS_DIRECTORY='ratings-artists'
+RATINGS_ALBUMS_DIRECTORY='albums_ratings'
+RATINGS_ARTISTS_DIRECTORY='artists_ratings'
 USERS_DIRECTORY='users'
 
 # MapR-DB JSON Tables

--- a/doc/tutorials/004-import-the-data-set.md
+++ b/doc/tutorials/004-import-the-data-set.md
@@ -323,7 +323,7 @@ Contains `175413` Album Rating JSON documents, which are ready to be imported in
   
 </details>
 
-### rating-artists
+### artists_ratings
 
 Contains `316065` Artist Rating JSON documents, which are ready to be imported into MapR-DB JSON Table. 
 <details> 
@@ -400,7 +400,7 @@ $ hadoop fs -copyFromLocal artists/ /tmp/artists
 $ hadoop fs -copyFromLocal languages/ /tmp/languages
 $ hadoop fs -copyFromLocal users/ /tmp/users
 $ hadoop fs -copyFromLocal albums_ratings/ /tmp/albums_ratings
-$ hadoop fs -copyFromLocal albums_artists/ /tmp/artists_ratings
+$ hadoop fs -copyFromLocal artists_ratings/ /tmp/artists_ratings
 ```
 
 You can also use a simple file copy using NFS if you have mounted MapR File System on your development environment.


### PR DESCRIPTION
1) Corrected albums_ratings and artists_ratings directory names

2) Set default archive name to dataset.tar.gz to match what the script indicates is the default